### PR TITLE
use unixtime

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -446,7 +446,7 @@ type Candle @entity {
 
   market: String!
   timeFormat: Int!
-  time: Date!
+  timestamp: BigInt!
 
   openX96: BigInt!
   highX96: BigInt!
@@ -455,8 +455,7 @@ type Candle @entity {
   baseAmount: BigInt!
   quoteAmount: BigInt!
 
-  "last updated block timestamp"
-  timestamp: BigInt!
+  updatedAt: BigInt!
 }
 
 type DaySummary @entity {

--- a/src/mappings/perpdexExchange.ts
+++ b/src/mappings/perpdexExchange.ts
@@ -297,7 +297,7 @@ export async function handleLiquidityAddedExchange(
 
   await createCandle(
     liquidityAddedExchange.market,
-    event.blockTimestamp,
+    BigInt(event.blockTimestamp.getTime()),
     liquidityAddedExchange.sharePriceAfterX96,
     liquidityAddedExchange.baseBalancePerShareX96,
     BI_ZERO,
@@ -394,7 +394,7 @@ export async function handleLiquidityRemovedExchange(
 
   await createCandle(
     liquidityRemovedExchange.market,
-    event.blockTimestamp,
+    BigInt(event.blockTimestamp.getTime()),
     liquidityRemovedExchange.sharePriceAfterX96,
     liquidityRemovedExchange.baseBalancePerShareX96,
     BI_ZERO,
@@ -505,7 +505,7 @@ export async function handlePositionLiquidated(
 
   await createCandle(
     positionLiquidated.market,
-    event.blockTimestamp,
+    BigInt(event.blockTimestamp.getTime()),
     positionLiquidated.sharePriceAfterX96,
     positionLiquidated.baseBalancePerShareX96,
     positionLiquidated.base,
@@ -597,7 +597,7 @@ export async function handlePositionChanged(
 
   await createCandle(
     positionChanged.market,
-    event.blockTimestamp,
+    BigInt(event.blockTimestamp.getTime()),
     positionChanged.sharePriceAfterX96,
     positionChanged.baseBalancePerShareX96,
     positionChanged.base,

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -142,7 +142,7 @@ export async function getOrCreateMarket(marketAddr: string): Promise<Market> {
 
 async function doCreateCandle(
   marketAddr: string,
-  time: Date,
+  time: bigint,
   timeFormat: number,
   priceX96: bigint,
   baseAmount: bigint,
@@ -153,7 +153,7 @@ async function doCreateCandle(
     ohlc = new Candle(`${marketAddr}-${timeFormat}-${time}`);
     ohlc.market = marketAddr;
     ohlc.timeFormat = timeFormat;
-    ohlc.time = time;
+    ohlc.timestamp = time;
     ohlc.openX96 = priceX96;
     ohlc.highX96 = priceX96;
     ohlc.lowX96 = priceX96;
@@ -169,17 +169,17 @@ async function doCreateCandle(
   ohlc.closeX96 = priceX96;
   ohlc.baseAmount += baseAmount;
   ohlc.quoteAmount += quoteAmount;
-  ohlc.timestamp = BigInt(time.getTime());
+  ohlc.updatedAt = time;
   await ohlc.save();
 }
 
-const roundTime = (time: Date, interval: number) => {
-  return new Date(Math.floor(time.getTime() / interval) * interval);
+const roundTime = (time: bigint, interval: number) => {
+  return BigInt(Math.floor(Number(time) / interval)) * BigInt(interval);
 };
 
 export async function createCandle(
   marketAddr: string,
-  time: Date,
+  time: bigint,
   sharePriceX96: bigint,
   baseBalancePerShareX96: bigint,
   baseShare: bigint,


### PR DESCRIPTION
changes

- use unixtime in candle fields

reason

- There is a sense of unity because unix timestamp is used in other timestamp fields.
- Seconds are enough for accuracy
- If it is Date, it becomes necessary to handle the time zone and it becomes complicated.